### PR TITLE
Support custom suffix for resources

### DIFF
--- a/src/Atc.Azure.Options/Providers/INamingProvider.cs
+++ b/src/Atc.Azure.Options/Providers/INamingProvider.cs
@@ -5,5 +5,7 @@ namespace Atc.Azure.Options.Providers
     public interface INamingProvider
     {
         string GetResourceName(EnvironmentOptions options, NamingOptions namingOptions);
+
+        string GetResourceName(EnvironmentOptions options, NamingOptions namingOptions, string suffix);
     }
 }

--- a/src/Atc.Azure.Options/Providers/NamingProvider.cs
+++ b/src/Atc.Azure.Options/Providers/NamingProvider.cs
@@ -5,10 +5,14 @@ namespace Atc.Azure.Options.Providers
     public class NamingProvider : INamingProvider
     {
         public string GetResourceName(EnvironmentOptions options, NamingOptions namingOptions)
+            => GetResourceName(options, namingOptions, suffix: string.Empty);
+
+        public string GetResourceName(EnvironmentOptions options, NamingOptions namingOptions, string suffix)
             => string.Concat(
                 namingOptions.CompanyAbbreviation,
                 namingOptions.SystemAbbreviation,
                 options.EnvironmentName,
-                namingOptions.ServiceAbbreviation);
+                namingOptions.ServiceAbbreviation,
+                suffix);
     }
 }

--- a/src/Atc.Azure.Options/Providers/NamingProvider.cs
+++ b/src/Atc.Azure.Options/Providers/NamingProvider.cs
@@ -5,7 +5,7 @@ namespace Atc.Azure.Options.Providers
     public class NamingProvider : INamingProvider
     {
         public string GetResourceName(EnvironmentOptions options, NamingOptions namingOptions)
-            => GetResourceName(options, namingOptions, suffix: string.Empty);
+            => GetResourceName(options, namingOptions, string.Empty);
 
         public string GetResourceName(EnvironmentOptions options, NamingOptions namingOptions, string suffix)
             => string.Concat(


### PR DESCRIPTION
This PR adds an overload to `INamingProvider.GetResourceName` to support custom suffixes for resources.
Some projects need multiple resources of the same type. In this case, a suffix can be used to identify resources and resolve name clashes.
Other projects may simply have a standard where the resource type abbreviation is appended to the resource.
