### PR TITLE
Introduced IAzureCredentialOptionsProvider

### DIFF
--- a/src/Atc.Azure.Options/GlobalUsings.cs
+++ b/src/Atc.Azure.Options/GlobalUsings.cs
@@ -1,3 +1,4 @@
+global using Atc.Azure.Options.Authorization;
 global using Atc.Azure.Options.Cosmos;
 global using Atc.Azure.Options.Environment;
 global using Atc.Azure.Options.Providers;

--- a/src/Atc.Azure.Options/Providers/AzureCredentialOptionsProvider.cs
+++ b/src/Atc.Azure.Options/Providers/AzureCredentialOptionsProvider.cs
@@ -1,0 +1,26 @@
+using Atc.Azure.Options.Authorization;
+
+namespace Atc.Azure.Options.Providers;
+
+public class AzureCredentialOptionsProvider : IAzureCredentialOptionsProvider
+{
+    public DefaultAzureCredentialOptions GetAzureCredentialOptions(
+        EnvironmentOptions environmentOptions,
+        ClientAuthorizationOptions authorizationOptions)
+        => GetAzureCredentialOptions(environmentOptions, authorizationOptions.TenantId);
+
+    public DefaultAzureCredentialOptions GetAzureCredentialOptions(
+        EnvironmentOptions environmentOptions,
+        string tenantId)
+        => new DefaultAzureCredentialOptions
+        {
+            SharedTokenCacheTenantId = tenantId,
+            VisualStudioTenantId = tenantId,
+            VisualStudioCodeTenantId = tenantId,
+            ExcludeManagedIdentityCredential = environmentOptions.EnvironmentType == EnvironmentType.Local,
+            ExcludeAzurePowerShellCredential = true,
+            ExcludeInteractiveBrowserCredential = true,
+            ExcludeSharedTokenCacheCredential = true,
+            ExcludeEnvironmentCredential = true,
+        };
+}

--- a/src/Atc.Azure.Options/Providers/AzureCredentialOptionsProvider.cs
+++ b/src/Atc.Azure.Options/Providers/AzureCredentialOptionsProvider.cs
@@ -1,5 +1,3 @@
-using Atc.Azure.Options.Authorization;
-
 namespace Atc.Azure.Options.Providers;
 
 public class AzureCredentialOptionsProvider : IAzureCredentialOptionsProvider

--- a/src/Atc.Azure.Options/Providers/IAzureCredentialOptionsProvider.cs
+++ b/src/Atc.Azure.Options/Providers/IAzureCredentialOptionsProvider.cs
@@ -1,5 +1,3 @@
-using Atc.Azure.Options.Authorization;
-
 namespace Atc.Azure.Options.Providers;
 
 public interface IAzureCredentialOptionsProvider

--- a/src/Atc.Azure.Options/Providers/IAzureCredentialOptionsProvider.cs
+++ b/src/Atc.Azure.Options/Providers/IAzureCredentialOptionsProvider.cs
@@ -1,0 +1,14 @@
+using Atc.Azure.Options.Authorization;
+
+namespace Atc.Azure.Options.Providers;
+
+public interface IAzureCredentialOptionsProvider
+{
+    DefaultAzureCredentialOptions GetAzureCredentialOptions(
+        EnvironmentOptions environmentOptions,
+        ClientAuthorizationOptions authorizationOptions);
+
+    DefaultAzureCredentialOptions GetAzureCredentialOptions(
+        EnvironmentOptions environmentOptions,
+        string tenantId);
+}


### PR DESCRIPTION
Added the interface IAzureCredentialOptionsProvider and a default implementation.

This is an attempt to streamline the Managed Identity experience as an alternative to connection strings.

It is intended to be used in e.g. ```Atc.Azure.Messaging```, but could also be used in the ```Atc.Azure.Options.Extensions``` namespace for a default configuring of the DefaultAzureCredentialOptions. 